### PR TITLE
Add defaultState option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ persistStore(store, {
 ```
 ## Configuration
 
-| Attr         | Type   | Default           | Notes                                               |
-| ------------ | ------ | ----------------- | --------------------------------------------------- |
-| expireKey    | String | false             | Name of the attribute holding the expire date value |
-| defaultState | Any    | {}                | Shape of the state after expirations happen         |
+| Attr         | Type   | Default            | Notes                                               |
+| ------------ | ------ | ------------------ | --------------------------------------------------- |
+| expireKey    | String | 'persistExpiresAt' | Name of the attribute holding the expire date value |
+| defaultState | Any    | {}                 | Shape of the state after expirations happen         |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Add expiration to your persisted store.
 import createExpirationTransform from 'redux-persist-transform-expire';
 
 const expireTransform = createExpirationTransform({
-  expireKey: 'customExpiresAt'
+  expireKey: 'customExpiresAt',
+  defaultState: {
+    custom: 'values'
+  }
 });
 
 persistStore(store, {
@@ -18,3 +21,9 @@ persistStore(store, {
 });
 
 ```
+## Configuration
+
+| Attr         | Type   | Default           | Notes                                               |
+| ------------ | ------ | ----------------- | --------------------------------------------------- |
+| expireKey    | String | false             | Name of the attribute holding the expire date value |
+| defaultState | Any    | {}                | Shape of the state after expirations happen         |

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var PERSIST_EXPIRE_DEFAULT_KEY = 'persistExpiresAt';
 module.exports = function (config) {
   config = config || {};
   config.expireKey = config.expireKey || PERSIST_EXPIRE_DEFAULT_KEY;
+  config.defaultState = config.defaultState || {};
 
   function dateToUnix (date) {
     return +(date.getTime() / 1000).toFixed(0);
@@ -36,7 +37,7 @@ module.exports = function (config) {
       }
 
       if (dateToUnix(new Date(expireDate)) < dateToUnix(new Date())) {
-        this.update({});
+        this.update(config.defaultState);
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-persist-transform-expire",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Add expiration to your persisted store",
   "main": "index.js",
   "scripts": {

--- a/test/expire-tests.js
+++ b/test/expire-tests.js
@@ -205,4 +205,41 @@ describe('Redux persists transform expire', function () {
 
     done();
   });
+
+  it('should allow a user to override the default state', function (done) {
+    var state = {
+      app: {
+        reducer: {
+          data: {
+            values: [1, 2],
+            persistExpiresAt: moment().subtract(1, 'hour').toDate()
+          }
+        }
+      }
+    };
+
+    var config = {
+      defaultState: {
+        values: [3]
+      }
+    };
+
+    var transform = createExpireTransform(config);
+
+    var inboundOutputState = transform.in(state);
+    var outboundOutputState = transform.out(state);
+
+    expect(inboundOutputState).to.eql(state);
+    expect(outboundOutputState).to.eql({
+      app: {
+        reducer: {
+          data: {
+            values: [3]
+          }
+        }
+      }
+    });
+
+    done();
+  });
 });


### PR DESCRIPTION
The user can define specific states for after-expired reducers.

Example case scenario:

1. The app renders an onboarding at the first start up
2. This onboarding shall never be shown again
3. The app expires the navigation history every 24 hours
4. After expiration happens, the history shall not be at `/onboarding` but `/`

Hope it fits the project ;)