### PR TITLE
extend readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ persistStore(store, {
 });
 
 ```
+Your expires key should be present in each reducer, which should be expired. E.g.
+```
+// top most reducer
+{
+  reducerOne: {
+    persistExpiresAt: '2017-04-11T15:46:54.338Z'
+  },
+  reducerTwo: {
+    persistExpiresAt: '2017-04-11T15:46:54.338Z'
+  }
+}
+```
+
+
 ## Configuration
 
 | Attr         | Type   | Default            | Notes                                               |


### PR DESCRIPTION
I wanted to clarify where to place `persistExpiresAt` key in reducers. It was really not clear for us. We thought we should create top most reducer with name `persistExpiresAt`, which will expire all reducers.